### PR TITLE
Use OTTOMAN_CONNECTION_STRING as connection string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import process from "process";
 import { ottoman } from "./ottoman-global-config";
 import App from './app';
 import HotelsController from './hotels/hotels.controller';
@@ -15,12 +16,7 @@ const app = new App(
 
 const main = async () => {
   try {
-    await ottoman.connect({
-      bucketName: 'travel-sample',
-      connectionString: 'couchbase://localhost:8091',
-      username: 'Administrator',
-      password: 'password',
-    });
+    await ottoman.connect(process.env.OTTOMAN_CONNECTION_STRING!);
     await ottoman.start();
     app.listen();
   } catch (e) {


### PR DESCRIPTION
The README talks about using an .env file, but the code example used
hardcoded credentials. This commit replaces those with the value of the
OTTOMAN_CONNECTION_STRING environment variable.